### PR TITLE
chore: initialize discourse plugin skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# fortune_gpt
+# Fortune GPT
+
+A starter Discourse plugin integrating GPT-based fortunes into Discourse.
+
+## Development
+
+This repository contains a Discourse plugin skeleton. To get started, check out [Discourse Plugin Development documentation](https://meta.discourse.org/t/beginners-guide-to-creating-discourse-plugins-part-1/30515).

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,0 +1,3 @@
+en:
+  site_settings:
+    fortune_gpt_enabled: "Enable the Fortune GPT plugin"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,4 @@
+plugins:
+  fortune_gpt_enabled:
+    default: false
+    type: bool

--- a/lib/fortune_gpt.rb
+++ b/lib/fortune_gpt.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module ::FortuneGPT
+end
+
+require_relative 'fortune_gpt/engine'

--- a/lib/fortune_gpt/engine.rb
+++ b/lib/fortune_gpt/engine.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module ::FortuneGPT
+  class Engine < ::Rails::Engine
+    engine_name 'fortune_gpt'
+    isolate_namespace FortuneGPT
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# name: fortune-gpt
+# about: A starter plugin integrating GPT-based fortunes into Discourse
+# version: 0.1
+# authors: fortune_gpt Team
+# url: https://github.com/example/fortune_gpt
+
+enabled_site_setting :fortune_gpt_enabled
+
+after_initialize do
+  # Code in this block runs after Discourse is fully initialized
+end


### PR DESCRIPTION
## Summary
- scaffold plugin with metadata and after_initialize hook
- define FortuneGPT module and engine
- add settings, locale, and README documentation

## Testing
- `ruby -c plugin.rb`
- `ruby -c lib/fortune_gpt.rb`
- `ruby -c lib/fortune_gpt/engine.rb`
- `ruby -ryaml -e 'YAML.load_file("config/settings.yml"); puts "settings ok"'`
- `ruby -ryaml -e 'YAML.load_file("config/locales/server.en.yml"); puts "locales ok"'`


------
https://chatgpt.com/codex/tasks/task_e_68903d7f983c83309aad9522ae3861b7