### PR TITLE
Add basic FortuneGPT plugin skeleton

### DIFF
--- a/app/controllers/fortune_gpt/fortune_controller.rb
+++ b/app/controllers/fortune_gpt/fortune_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module FortuneGPT
+  class FortuneController < ::ApplicationController
+    requires_plugin ::FortuneGPT
+
+    def index
+      render json: { fortune: "Good luck is coming your way" }
+    end
+  end
+end

--- a/assets/javascripts/discourse/components/fortune-display.js.es6
+++ b/assets/javascripts/discourse/components/fortune-display.js.es6
@@ -1,0 +1,5 @@
+import Component from "@ember/component";
+
+export default Component.extend({
+  // Future Ember component logic for displaying fortunes will live here
+});

--- a/lib/fortune_gpt.rb
+++ b/lib/fortune_gpt.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require_relative "fortune_gpt/engine"
+
+module FortuneGPT
+  # Additional module code can be added here in the future
+end

--- a/lib/fortune_gpt/engine.rb
+++ b/lib/fortune_gpt/engine.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module FortuneGPT
+  class Engine < ::Rails::Engine
+    engine_name "fortune_gpt"
+    isolate_namespace FortuneGPT
+
+    initializer "fortune_gpt.assets" do |app|
+      app.config.assets.precompile += %w[fortune-display.js]
+    end
+  end
+end
+
+FortuneGPT::Engine.routes.draw do
+  get "/fortune" => "fortune#index"
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# name: fortune_gpt
+# about: Fortune telling plugin powered by GPT
+# version: 0.1
+# authors: ChatGPT
+# url: https://example.com/fortune_gpt
+
+require_relative "lib/fortune_gpt"
+
+after_initialize do
+  ::Discourse::Application.routes.append do
+    mount ::FortuneGPT::Engine, at: "/fortune_gpt"
+  end
+end
+


### PR DESCRIPTION
## Summary
- set up plugin skeleton and mount engine
- add fortune controller and example route
- stub Ember component for future UI work

## Testing
- `rake` *(fails: No Rakefile found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68904014f2388330b921d088b9446b5e