### PR TITLE
Add fortune tables migration

### DIFF
--- a/db/migrate/CreateFortuneTables.rb
+++ b/db/migrate/CreateFortuneTables.rb
@@ -1,0 +1,19 @@
+class CreateFortuneTables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :fortune_gpt_fortunes do |t|
+      t.text :text, null: false
+
+      t.timestamps
+    end
+
+    create_table :fortune_gpt_user_fortunes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :picked_on, null: false
+      t.references :fortune_gpt_fortune, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :fortune_gpt_user_fortunes, [:user_id, :picked_on], unique: true, name: 'idx_user_fortunes_on_user_and_picked_on'
+  end
+end


### PR DESCRIPTION
## Summary
- add fortunes table to store fortune text
- track which user picked which fortune and when, with unique per-day limit

## Testing
- `ruby -c db/migrate/CreateFortuneTables.rb`
- `bundle exec rubocop` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_6890467a54148330a76ae09eeff4e274