### PR TITLE
Specify fortunes table for user fortune reference

### DIFF
--- a/db/migrate/CreateFortuneTables.rb
+++ b/db/migrate/CreateFortuneTables.rb
@@ -9,7 +9,7 @@ class CreateFortuneTables < ActiveRecord::Migration[6.0]
     create_table :fortune_gpt_user_fortunes do |t|
       t.references :user, null: false, foreign_key: true
       t.date :picked_on, null: false
-      t.references :fortune_gpt_fortune, null: false, foreign_key: true
+      t.references :fortune_gpt_fortune, null: false, foreign_key: { to_table: :fortune_gpt_fortunes }
 
       t.timestamps
     end


### PR DESCRIPTION
## Summary
- clarify migration foreign key for fortune_gpt_user_fortunes

## Testing
- `bundle exec rubocop` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `bundle exec rspec` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_6890488ba4f88330b380b202e61f61df