### PR TITLE
Add daily fortune banner feature

### DIFF
--- a/app/controllers/fortune_gpt/fortune_controller.rb
+++ b/app/controllers/fortune_gpt/fortune_controller.rb
@@ -3,9 +3,72 @@
 module FortuneGPT
   class FortuneController < ::ApplicationController
     requires_plugin ::FortuneGPT
+    before_action :ensure_logged_in
+    before_action :ensure_fortune_enabled
 
     def index
-      render json: { fortune: "Good luck is coming your way" }
+      user_fortune = FortuneGPT::UserFortune.find_by(
+        user_id: current_user.id,
+        picked_on: Date.today,
+      )
+
+      render json: { data: serialize_fortune(user_fortune) }, status: 200
+    end
+
+    def create
+      today = Date.today
+      user_fortune = FortuneGPT::UserFortune.find_by(user_id: current_user.id, picked_on: today)
+
+      if user_fortune
+        render json: {
+                 errors: [
+                   {
+                     message: I18n.t("fortune_gpt.errors.already_picked", default: "fortune already picked"),
+                   },
+                 ],
+               },
+               status: 409
+        return
+      end
+
+      fortune = FortuneGPT::Fortune.order("RANDOM()").first
+
+      begin
+        user_fortune = FortuneGPT::UserFortune.create!(
+          user: current_user,
+          picked_on: today,
+          fortune: fortune,
+        )
+      rescue ActiveRecord::RecordNotUnique
+        user_fortune = FortuneGPT::UserFortune.find_by(user_id: current_user.id, picked_on: today)
+        render json: {
+                 errors: [
+                   {
+                     message: I18n.t("fortune_gpt.errors.already_picked", default: "fortune already picked"),
+                   },
+                 ],
+               },
+               status: 409
+        return
+      end
+
+      render json: { data: serialize_fortune(user_fortune) }, status: 201
+    end
+
+    private
+
+    def ensure_fortune_enabled
+      raise Discourse::NotFound unless SiteSetting.fortune_gpt_enabled
+    end
+
+    def serialize_fortune(user_fortune)
+      return nil unless user_fortune
+
+      {
+        id: user_fortune.id,
+        text: user_fortune.fortune.text,
+        picked_on: user_fortune.picked_on,
+      }
     end
   end
 end

--- a/app/models/fortune_gpt/fortune.rb
+++ b/app/models/fortune_gpt/fortune.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module FortuneGPT
+  class Fortune < ::ActiveRecord::Base
+    self.table_name = 'fortune_gpt_fortunes'
+
+    has_many :user_fortunes,
+             class_name: 'FortuneGPT::UserFortune',
+             foreign_key: 'fortune_gpt_fortune_id'
+  end
+end

--- a/app/models/fortune_gpt/user_fortune.rb
+++ b/app/models/fortune_gpt/user_fortune.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module FortuneGPT
+  class UserFortune < ::ActiveRecord::Base
+    self.table_name = 'fortune_gpt_user_fortunes'
+
+    belongs_to :user
+    belongs_to :fortune,
+               class_name: 'FortuneGPT::Fortune',
+               foreign_key: 'fortune_gpt_fortune_id'
+
+    validates :user_id, uniqueness: { scope: :picked_on }
+  end
+end

--- a/assets/javascripts/discourse/components/fortune-display.js.es6
+++ b/assets/javascripts/discourse/components/fortune-display.js.es6
@@ -1,5 +1,33 @@
 import Component from "@ember/component";
+import { ajax } from "discourse/lib/ajax";
 
 export default Component.extend({
-  // Future Ember component logic for displaying fortunes will live here
+  fortune: null,
+
+  init() {
+    this._super(...arguments);
+    this.loadExisting();
+  },
+
+  loadExisting() {
+    ajax("/fortune_gpt/fortune").then((result) => {
+      if (result.data) {
+        this.set("fortune", result.data.text);
+      }
+    });
+  },
+
+  actions: {
+    pickFortune() {
+      ajax("/fortune_gpt/fortune", { method: "POST" })
+        .then((result) => {
+          this.set("fortune", result.data.text);
+        })
+        .catch((error) => {
+          if (error && error.jqXHR && error.jqXHR.status === 409) {
+            this.loadExisting();
+          }
+        });
+    },
+  },
 });

--- a/assets/javascripts/discourse/connectors/welcome-banner__wrap/fortune-gpt.hbs
+++ b/assets/javascripts/discourse/connectors/welcome-banner__wrap/fortune-gpt.hbs
@@ -1,0 +1,1 @@
+{{fortune-display}}

--- a/assets/javascripts/discourse/templates/components/fortune-display.hbs
+++ b/assets/javascripts/discourse/templates/components/fortune-display.hbs
@@ -1,0 +1,5 @@
+{{#if this.fortune}}
+  <div class="fortune-text">{{this.fortune}}</div>
+{{else}}
+  <button class="fortune-btn" {{action "pickFortune"}}>오늘의 운세 뽑기</button>
+{{/if}}

--- a/assets/javascripts/fortune-display.js
+++ b/assets/javascripts/fortune-display.js
@@ -1,0 +1,3 @@
+import "./discourse/components/fortune-display";
+import "./discourse/templates/components/fortune-display";
+import "./discourse/connectors/welcome-banner__wrap/fortune-gpt";

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,3 @@
+fortune_gpt_enabled:
+  default: true
+  client: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+fortunes = [
+  "행운이 가득한 하루가 될 거예요!",
+  "오늘은 새로운 도전을 시도해보세요.",
+  "반가운 소식을 듣게 될 것입니다.",
+  "작은 친절이 큰 기쁨을 가져다줄 거예요.",
+  "오랜 친구와의 만남이 즐거움을 선사할 것입니다."
+]
+
+fortunes.each do |text|
+  FortuneGPT::Fortune.find_or_create_by!(text: text)
+end

--- a/lib/fortune_gpt/engine.rb
+++ b/lib/fortune_gpt/engine.rb
@@ -5,12 +5,10 @@ module FortuneGPT
     engine_name "fortune_gpt"
     isolate_namespace FortuneGPT
 
-    initializer "fortune_gpt.assets" do |app|
-      app.config.assets.precompile += %w[fortune-display.js]
-    end
   end
 end
 
 FortuneGPT::Engine.routes.draw do
   get "/fortune" => "fortune#index"
+  post "/fortune" => "fortune#create"
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -8,6 +8,10 @@
 
 require_relative "lib/fortune_gpt"
 
+enabled_site_setting :fortune_gpt_enabled
+
+register_asset "javascripts/fortune-display.js", :client_side
+
 after_initialize do
   ::Discourse::Application.routes.append do
     mount ::FortuneGPT::Engine, at: "/fortune_gpt"


### PR DESCRIPTION
## Summary
- Show a fortune banner in the `welcome-banner__wrap` area
- Allow each user to draw one random fortune per day
- Store fortunes and seed preset messages
- Add structured API responses with explicit namespace and proper HTTP codes
- Register front-end assets without custom precompile step
- Guard fortune endpoints behind a `fortune_gpt_enabled` site setting and handle duplicate draws safely

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT: no such file or directory)*
- `bundle exec rake` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_689049958be48330871cddc638fa299e