### PR TITLE
Remove redundant asset registration

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -10,8 +10,6 @@ require_relative "lib/fortune_gpt"
 
 enabled_site_setting :fortune_gpt_enabled
 
-register_asset "javascripts/fortune-display.js", :client_side
-
 after_initialize do
   ::Discourse::Application.routes.append do
     mount ::FortuneGPT::Engine, at: "/fortune_gpt"


### PR DESCRIPTION
## Summary
- remove `register_asset` for fortune-display.js because assets/javascripts files are bundled automatically

## Testing
- `rake` *(fails: No Rakefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6890578573a0833092af3ab947568c44