### PR TITLE
feat: log fortune creation errors

### DIFF
--- a/app/controllers/fortune_gpt/fortune_controller.rb
+++ b/app/controllers/fortune_gpt/fortune_controller.rb
@@ -50,6 +50,18 @@ module FortuneGPT
                },
                status: 409
         return
+      rescue StandardError => e
+        Rails.logger.error("Error creating fortune for user #{current_user.id}: #{e.message}")
+        Rails.logger.error(e.backtrace.join("\\n"))
+        render json: {
+                 errors: [
+                   {
+                     message: I18n.t("fortune_gpt.errors.internal_server_error", default: "internal server error"),
+                   },
+                 ],
+               },
+               status: 500
+        return
       end
 
       render json: { data: serialize_fortune(user_fortune) }, status: 201


### PR DESCRIPTION
## Summary
- log unexpected errors when creating a fortune

## Testing
- `bundle exec rspec` *(fails: Could not locate Gemfile)*
- `ruby -c app/controllers/fortune_gpt/fortune_controller.rb`


------
https://chatgpt.com/codex/tasks/task_e_68905d96907c8330b9d7a96264cc3d90