### PR TITLE
feat: log and surface fortune creation errors

### DIFF
--- a/app/controllers/fortune_gpt/fortune_controller.rb
+++ b/app/controllers/fortune_gpt/fortune_controller.rb
@@ -23,7 +23,7 @@ module FortuneGPT
         render json: {
                  errors: [
                    {
-                     message: I18n.t("fortune_gpt.errors.already_picked", default: "fortune already picked"),
+                     message: I18n.t("fortune.errors.already_picked", default: "fortune already picked"),
                    },
                  ],
                },
@@ -44,11 +44,23 @@ module FortuneGPT
         render json: {
                  errors: [
                    {
-                     message: I18n.t("fortune_gpt.errors.already_picked", default: "fortune already picked"),
+                     message: I18n.t("fortune.errors.already_picked", default: "fortune already picked"),
                    },
                  ],
                },
                status: 409
+        return
+      rescue StandardError => e
+        Rails.logger.error("Error creating fortune for user #{current_user.id}: #{e.message}")
+        Rails.logger.error(e.backtrace.join("\\n"))
+        render json: {
+                 errors: [
+                   {
+                     message: e.message,
+                   },
+                 ],
+               },
+               status: 200
         return
       end
 
@@ -58,7 +70,7 @@ module FortuneGPT
     private
 
     def ensure_fortune_enabled
-      raise Discourse::NotFound unless SiteSetting.fortune_gpt_enabled
+      raise Discourse::NotFound unless SiteSetting.fortune_enabled
     end
 
     def serialize_fortune(user_fortune)

--- a/assets/javascripts/discourse/components/fortune-display.js.es6
+++ b/assets/javascripts/discourse/components/fortune-display.js.es6
@@ -11,6 +11,12 @@ export default Component.extend({
 
   loadExisting() {
     ajax("/fortune_gpt/fortune").then((result) => {
+      if (result.errors) {
+        // eslint-disable-next-line no-console
+        console.error(result.errors[0].message);
+        return;
+      }
+
       if (result.data) {
         this.set("fortune", result.data.text);
       }
@@ -21,6 +27,12 @@ export default Component.extend({
     pickFortune() {
       ajax("/fortune_gpt/fortune", { method: "POST" })
         .then((result) => {
+          if (result.errors) {
+            // eslint-disable-next-line no-console
+            console.error(result.errors[0].message);
+            return;
+          }
+
           this.set("fortune", result.data.text);
         })
         .catch((error) => {

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,3 @@
-fortune_gpt_enabled:
+fortune_enabled:
   default: true
   client: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -8,7 +8,7 @@
 
 require_relative "lib/fortune_gpt"
 
-enabled_site_setting :fortune_gpt_enabled
+enabled_site_setting :fortune_enabled
 
 after_initialize do
   ::Discourse::Application.routes.append do


### PR DESCRIPTION
## Summary
- log unexpected errors when creating a fortune
- return error details with a 200 status so the client can handle them
- rename `fortune_gpt` settings and error keys to `fortune`

## Testing
- `bundle exec rspec` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `ruby -c app/controllers/fortune_gpt/fortune_controller.rb`
- `node --check --input-type=module < assets/javascripts/discourse/components/fortune-display.js.es6`
- `ruby -c plugin.rb`
- `ruby -ryaml -e "YAML.load_file('config/settings.yml')"`


------
https://chatgpt.com/codex/tasks/task_e_68905d96907c8330b9d7a96264cc3d90