### PR TITLE
Mount fortune display using HTML class

### DIFF
--- a/assets/javascripts/discourse/connectors/welcome-banner__wrap/fortune-gpt.hbs
+++ b/assets/javascripts/discourse/connectors/welcome-banner__wrap/fortune-gpt.hbs
@@ -1,1 +1,0 @@
-{{fortune-display}}

--- a/assets/javascripts/discourse/initializers/fortune-banner.js
+++ b/assets/javascripts/discourse/initializers/fortune-banner.js
@@ -1,0 +1,20 @@
+import { apiInitializer } from "discourse/lib/api";
+
+export default apiInitializer("0.11.1", (api) => {
+  api.onPageChange(() => {
+    const banner = document.querySelector(".welcome-banner__wrap");
+    // Log the banner element to help verify it exists on the current page
+    // and avoid silently failing when the container is missing.
+    /* eslint-disable no-console */
+    console.debug("FortuneGPT banner element:", banner);
+    /* eslint-enable no-console */
+    if (!banner || banner.querySelector(".fortune-gpt-container")) {
+      return;
+    }
+
+    const mountPoint = document.createElement("div");
+    mountPoint.className = "fortune-gpt-container";
+    banner.appendChild(mountPoint);
+    api.mountComponent("fortune-display", mountPoint);
+  });
+});

--- a/assets/javascripts/discourse/initializers/register-fortune-display.js
+++ b/assets/javascripts/discourse/initializers/register-fortune-display.js
@@ -1,0 +1,5 @@
+import { apiInitializer } from "discourse/lib/api";
+
+export default apiInitializer("0.11.1", (api) => {
+  api.registerComponent("fortune-display");
+});

--- a/assets/javascripts/fortune-display.js
+++ b/assets/javascripts/fortune-display.js
@@ -1,3 +1,4 @@
 import "./discourse/components/fortune-display";
 import "./discourse/templates/components/fortune-display";
-import "./discourse/connectors/welcome-banner__wrap/fortune-gpt";
+import "./discourse/initializers/register-fortune-display";
+import "./discourse/initializers/fortune-banner";

--- a/assets/stylesheets/common/fortune-gpt.scss
+++ b/assets/stylesheets/common/fortune-gpt.scss
@@ -1,0 +1,4 @@
+.fortune-gpt-container {
+  margin-top: 1em;
+  text-align: center;
+}

--- a/plugin.rb
+++ b/plugin.rb
@@ -8,6 +8,9 @@
 
 require_relative "lib/fortune_gpt"
 
+register_asset "javascripts/fortune-display.js"
+register_asset "stylesheets/common/fortune-gpt.scss"
+
 enabled_site_setting :fortune_enabled
 
 after_initialize do


### PR DESCRIPTION
## Summary
- register `fortune-display` with plugin API so initializer can mount component into `.welcome-banner__wrap`
- add container stylesheet and register assets for JS/CSS
- log banner lookup to help debug `.welcome-banner__wrap` presence

## Testing
- `npm test` (fails: Could not read package.json)
- `bundle exec rake` (fails: Could not locate Gemfile or .bundle/ directory)


------
https://chatgpt.com/codex/tasks/task_e_689065f118008330b7b671dd0d547932